### PR TITLE
update runner.py refresh method to instantiate FilePath class and use…

### DIFF
--- a/doc/Vdebug.txt
+++ b/doc/Vdebug.txt
@@ -798,7 +798,9 @@ The default options look like this: >
     \    "watch_window_style" : 'expanded',
     \    "marker_default" : '⬦',
     \    "marker_closed_tree" : '▸',
-    \    "marker_open_tree" : '▾'
+    \    "marker_open_tree" : '▾',
+    \    "continuous_mode"  : 0,
+    \    "powerline_patched_font" : 0
     \}
 <
 You can either use the multi-line notation like above, or set individual keys:
@@ -818,6 +820,7 @@ g:vdebug_options["port"] (default = 9000)
 
                                                         *VdebugOptions-server*
 g:vdebug_options["server"] (default = "localhost")      
+    This option is deprecated, no need to set the server to listen for
     Sets the address that Vdebug will use to listen for connections. It
     defaults to localhost, as it assumes that the debugger engine will be
     running on the same machine and also connecting to localhost. If you want
@@ -908,6 +911,16 @@ g:vdebug_options["continuous_mode"] (default = 0)
     session has finished, allowing for constant debugging across separate
     requests. Press <F6> during a debugging session to stop this, or <Ctrl-C>
     when Vdebug is listening.
+
+                                        *VdebugOptions-powerline_patched_font*
+g:vdebug_options["powerline_patched_font"] (default = 0)
+    If this option is enabled vdebug will try to use your patched font for
+    powerline to display symbols for breakpoints and current line marker. I 
+    recomend Sauce Code Pro.
+    https://github.com/powerline/fonts/tree/master/SourceCodePro
+    If you can see the below examples then your font will support this option.
+    Ex Pointer: ▶
+    Ex Breakpoint: ●
 
 ==============================================================================
 6. Key maps                                                       *VdebugKeys*

--- a/plugin/python/vdebug/runner.py
+++ b/plugin/python/vdebug/runner.py
@@ -113,7 +113,8 @@ class Runner:
                 stack_res = self.update_stack()
                 stack = stack_res.get_stack()
 
-                self.cur_file = vdebug.util.LocalFilePath(stack[0].get('filename'))
+                file_path = vdebug.util.FilePath(stack[0].get('filename'))
+                self.cur_file = file_path.as_local()
                 self.cur_lineno = stack[0].get('lineno')
 
                 vdebug.log.Log("Moving to current position in source window")

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -209,7 +209,8 @@ class Ui(vdebug.ui.interface.Ui):
 class SourceWindow(vdebug.ui.interface.Window):
 
     file = None
-    pointer_sign_id = '6145'
+    pointer_sign_id = 6145
+    prevpointer_sign_id = 6144
     breakpoint_sign_id = '6146'
 
     def __init__(self,ui,winno):
@@ -234,7 +235,7 @@ class SourceWindow(vdebug.ui.interface.Window):
 
     def set_line(self,lineno):
         self.focus()
-        vim.command("normal %sggzz" % str(lineno))
+        vim.command("normal %szz" % str(lineno))
 
     def get_file(self):
         self.focus()
@@ -247,13 +248,15 @@ class SourceWindow(vdebug.ui.interface.Window):
     def place_pointer(self,line):
         vdebug.log.Log("Placing pointer sign on line "+str(line),\
                 vdebug.log.Logger.INFO)
-        self.remove_pointer()
-        vim.command('sign place '+self.pointer_sign_id+\
+        vim.command('sign place '+str(self.pointer_sign_id)+\
                 ' name=current line='+str(line)+\
                 ' file='+self.file)
+        self.remove_pointer()
+        self.pointer_sign_id += 1
+        self.prevpointer_sign_id += 1
 
     def remove_pointer(self):
-        vim.command('sign unplace %s' % self.pointer_sign_id)
+        vim.command('sign unplace %s' % str(self.prevpointer_sign_id))
 
 class Window(vdebug.ui.interface.Window):
     name = "WINDOW"

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -20,6 +20,7 @@
 
 " Do not source this script when python is not compiled in.
 if !has("python")
+    echom "vim with Python is required to use vdebug"
     finish
 endif
 
@@ -29,18 +30,18 @@ silent doautocmd User VdebugPre
 " /usr/local/share/vim/vim71/plugin/ if you're running Vim 7.1) or from the
 " home vim directory (usually ~/.vim/plugin/).
 if filereadable($VIMRUNTIME."/plugin/python/start_vdebug.py")
-  pyfile $VIMRUNTIME/plugin/start_vdebug.py
+    pyfile $VIMRUNTIME/plugin/start_vdebug.py
 elseif filereadable($HOME."/.vim/plugin/python/start_vdebug.py")
-  pyfile $HOME/.vim/plugin/python/start_vdebug.py
+    pyfile $HOME/.vim/plugin/python/start_vdebug.py
 else
-  " when we use pathogen for instance
-  let $CUR_DIRECTORY=expand("<sfile>:p:h")
+    " when we use pathogen for instance
+    let $CUR_DIRECTORY=expand("<sfile>:p:h")
 
-  if filereadable($CUR_DIRECTORY."/python/start_vdebug.py")
-    pyfile $CUR_DIRECTORY/python/start_vdebug.py
-  else
-    call confirm('vdebug.vim: Unable to find start_vdebug.py. Place it in either your home vim directory or in the Vim runtime directory.', 'OK')
-  endif
+    if filereadable($CUR_DIRECTORY."/python/start_vdebug.py")
+        pyfile $CUR_DIRECTORY/python/start_vdebug.py
+    else
+        call confirm('vdebug.vim: Unable to find start_vdebug.py. Place it in either your home vim directory or in the Vim runtime directory.', 'OK')
+    endif
 endif
 
 " Nice characters get screwed up on windows
@@ -51,9 +52,6 @@ elseif has('multi_byte') == 0
 else
     let g:vdebug_force_ascii = 0
 end
-if !exists("g:vdebug_powerline_fonts")
-    let g:vdebug_powerline_fonts = 0
-endif
 if !exists("g:vdebug_options")
     let g:vdebug_options = {}
 endif
@@ -71,36 +69,37 @@ if !exists("g:vdebug_leader_key")
 endif
 
 let g:vdebug_keymap_defaults = {
-\    "run" : "<F5>",
-\    "run_to_cursor" : "<F9>",
-\    "step_over" : "<F2>",
-\    "step_into" : "<F3>",
-\    "step_out" : "<F4>",
-\    "close" : "<F6>",
-\    "detach" : "<F7>",
-\    "set_breakpoint" : "<F10>",
-\    "get_context" : "<F11>",
-\    "eval_under_cursor" : "<F12>",
-\    "eval_visual" : "<Leader>e"
-\}
+            \    "run" : "<F5>",
+            \    "run_to_cursor" : "<F9>",
+            \    "step_over" : "<F2>",
+            \    "step_into" : "<F3>",
+            \    "step_out" : "<F4>",
+            \    "close" : "<F6>",
+            \    "detach" : "<F7>",
+            \    "set_breakpoint" : "<F10>",
+            \    "get_context" : "<F11>",
+            \    "eval_under_cursor" : "<F12>",
+            \    "eval_visual" : "<Leader>e"
+            \}
 
 let g:vdebug_options_defaults = {
-\    "port" : 9000,
-\    "timeout" : 20,
-\    "server" : 'localhost',
-\    "on_close" : 'detach',
-\    "break_on_open" : 1,
-\    "ide_key" : '',
-\    "debug_window_level" : 0,
-\    "debug_file_level" : 0,
-\    "debug_file" : "",
-\    "path_maps" : {},
-\    "watch_window_style" : 'expanded',
-\    "marker_default" : '⬦',
-\    "marker_closed_tree" : '▸',
-\    "marker_open_tree" : '▾',
-\    "continuous_mode"  : 0
-\}
+            \    "port" : 9000,
+            \    "timeout" : 20,
+            \    "server" : 'localhost',
+            \    "on_close" : 'detach',
+            \    "break_on_open" : 1,
+            \    "ide_key" : '',
+            \    "debug_window_level" : 0,
+            \    "debug_file_level" : 0,
+            \    "debug_file" : "",
+            \    "path_maps" : {},
+            \    "watch_window_style" : 'expanded',
+            \    "marker_default" : '⬦',
+            \    "marker_closed_tree" : '▸',
+            \    "marker_open_tree" : '▾',
+            \    "continuous_mode"  : 0,
+            \    "powerline_patched_font" : 0
+            \}
 
 " Different symbols for non unicode Vims
 if g:vdebug_force_ascii == 1
@@ -108,47 +107,6 @@ if g:vdebug_force_ascii == 1
     let g:vdebug_options_defaults["marker_closed_tree"] = '+'
     let g:vdebug_options_defaults["marker_open_tree"] = '-'
 endif
-
-" Create the top dog
-python debugger = DebuggerInterface()
-
-" Commands
-command! -nargs=? -complete=customlist,s:BreakpointTypes Breakpoint python debugger.set_breakpoint(<q-args>)
-command! VdebugStart python debugger.run()
-command! -nargs=? BreakpointRemove python debugger.remove_breakpoint(<q-args>)
-command! BreakpointWindow python debugger.toggle_breakpoint_window()
-command! -nargs=? VdebugEval python debugger.handle_eval(<q-args>)
-command! -nargs=+ -complete=customlist,s:OptionNames VdebugOpt python debugger.handle_opt(<f-args>)
-
-" Signs and highlighted lines for breakpoints, etc.
-if g:vdebug_powerline_fonts
-    sign define current text=▶ texthl=DbgCurrentSign linehl=DbgCurrentLine
-    sign define breakpt text=● texthl=DbgBreakptSign linehl=DbgBreakptLine
-else
-    sign define current text=-> texthl=DbgCurrentSign linehl=DbgCurrentLine
-    sign define breakpt text=B> texthl=DbgBreakptSign linehl=DbgBreakptLine
-endif
-if &t_Co == 256
-    hi default DbgCurrentLine term=reverse cterm=underline 
-    hi default DbgCurrentSign term=reverse ctermfg=46
-    hi default DbgBreakptLine term=reverse ctermbg=124
-    hi default DbgBreakptSign term=reverse ctermfg=124
-else
-    hi default DbgCurrentLine term=reverse ctermfg=White ctermbg=Red gui=underline
-    hi default DbgCurrentSign term=reverse ctermfg=White ctermbg=Red guifg=#ffffff guibg=#ff0000
-    hi default DbgBreakptLine term=reverse ctermfg=White ctermbg=Green guifg=#ffffff guibg=#00ff00
-    hi default DbgBreakptSign term=reverse ctermfg=White ctermbg=Green guifg=#ffffff guibg=#00ff00
-endif
-
-function! s:BreakpointTypes(A,L,P)
-    let arg_to_cursor = strpart(a:L,11,a:P)
-    let space_idx = stridx(arg_to_cursor,' ')
-    if space_idx == -1
-        return filter(['conditional ','exception ','return ','call ','watch '],'v:val =~ "^".a:A.".*"')
-    else
-        return []
-    endif
-endfunction
 
 " Reload options dictionary, by merging with default options.
 "
@@ -186,6 +144,51 @@ function! Vdebug_load_keymaps(keymaps)
     exe "vnoremap ".g:vdebug_keymap["eval_visual"]." :python debugger.handle_visual_eval()<cr>"
 endfunction
 
+call Vdebug_load_options(g:vdebug_options)
+call Vdebug_load_keymaps(g:vdebug_keymap)
+
+" Signs and highlighted lines for breakpoints, etc.
+if g:vdebug_options["powerline_patched_font"] == 1
+    sign define current text=▶ texthl=DbgCurrentSign linehl=DbgCurrentLine
+    sign define breakpt text=● texthl=DbgBreakptSign linehl=DbgBreakptLine
+else
+    sign define current text=-> texthl=DbgCurrentSign linehl=DbgCurrentLine
+    sign define breakpt text=B> texthl=DbgBreakptSign linehl=DbgBreakptLine
+endif
+
+if &t_Co == 256
+    hi default DbgCurrentLine term=reverse cterm=underline 
+    hi default DbgCurrentSign term=reverse ctermfg=46
+    hi default DbgBreakptLine term=reverse ctermbg=124
+    hi default DbgBreakptSign term=reverse ctermfg=124
+else
+    hi default DbgCurrentLine term=reverse ctermfg=White ctermbg=Red gui=underline
+    hi default DbgCurrentSign term=reverse ctermfg=White ctermbg=Red guifg=#ffffff guibg=#ff0000
+    hi default DbgBreakptLine term=reverse ctermfg=White ctermbg=Green guifg=#ffffff guibg=#00ff00
+    hi default DbgBreakptSign term=reverse ctermfg=White ctermbg=Green guifg=#ffffff guibg=#00ff00
+endif
+
+" Create the top dog
+python debugger = DebuggerInterface()
+
+" Commands
+command! -nargs=? -complete=customlist,s:BreakpointTypes Breakpoint python debugger.set_breakpoint(<q-args>)
+command! VdebugStart python debugger.run()
+command! -nargs=? BreakpointRemove python debugger.remove_breakpoint(<q-args>)
+command! BreakpointWindow python debugger.toggle_breakpoint_window()
+command! -nargs=? VdebugEval python debugger.handle_eval(<q-args>)
+command! -nargs=+ -complete=customlist,s:OptionNames VdebugOpt python debugger.handle_opt(<f-args>)
+
+function! s:BreakpointTypes(A,L,P)
+    let arg_to_cursor = strpart(a:L,11,a:P)
+    let space_idx = stridx(arg_to_cursor,' ')
+    if space_idx == -1
+        return filter(['conditional ','exception ','return ','call ','watch '],'v:val =~ "^".a:A.".*"')
+    else
+        return []
+    endif
+endfunction
+
 function! s:OptionNames(A,L,P)
     let arg_to_cursor = strpart(a:L,10,a:P)
     let space_idx = stridx(arg_to_cursor,' ')
@@ -202,12 +205,12 @@ function! s:OptionNames(A,L,P)
 endfunction
 
 function! Vdebug_get_visual_selection()
-  let [lnum1, col1] = getpos("'<")[1:2]
-  let [lnum2, col2] = getpos("'>")[1:2]
-  let lines = getline(lnum1, lnum2)
-  let lines[-1] = lines[-1][: col2 - 1]
-  let lines[0] = lines[0][col1 - 1:]
-  return join(lines, "\n")
+    let [lnum1, col1] = getpos("'<")[1:2]
+    let [lnum2, col2] = getpos("'>")[1:2]
+    let lines = getline(lnum1, lnum2)
+    let lines[-1] = lines[-1][: col2 - 1]
+    let lines[0] = lines[0][col1 - 1:]
+    return join(lines, "\n")
 endfunction
 
 function! Vdebug_edit(filename)
@@ -219,5 +222,3 @@ function! Vdebug_edit(filename)
 endfunction
 
 silent doautocmd User VdebugPost
-call Vdebug_load_options(g:vdebug_options)
-call Vdebug_load_keymaps(g:vdebug_keymap)


### PR DESCRIPTION
… as_local method

SourceWindow class now uses int for sign_id
SourceWindow class now uses a prevsign_id to eliminate jumpy interface
Pointer will center line but not move cursor to line
rearrange plugin logic to set options before processing code
update g:powerline_fonts to be included as g:vdebug_options['powerline_patched_font']
